### PR TITLE
feat: add student-relevant skills from VoltAgent/awesome-agent-skills…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
-<div align="center">
-
 # Awesome Skills & Plugins for Students
 
 A curated list of Claude Code, Cursor, and Copilot skills and plugins built for students: IB, IGCSE, college-bound, and anyone studying with an AI coding agent at their side.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-
-</div>
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 This is a curation list, not a code library. Every entry below links out to a skill or plugin maintained in its own repo. Add yours by opening a PR, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -21,6 +16,7 @@ Maintained by [StudentSuite](https://github.com/StudentSuite).
 - [STEM Subjects](#stem-subjects)
 - [Writing & Humanities](#writing--humanities)
 - [College Applications & Career](#college-applications--career)
+- [Google Workspace for Students](#google-workspace-for-students)
 - [Plugins](#plugins)
 - [Security Notice](#security-notice)
 - [Skill & Plugin Paths for Other AI Coding Assistants](#skill--plugin-paths-for-other-ai-coding-assistants)
@@ -28,27 +24,27 @@ Maintained by [StudentSuite](https://github.com/StudentSuite).
 - [Contributing](#contributing)
 - [License](#license)
 
+
 ## Skills
 
 ### IB & IGCSE Coursework
 
 IA, EE, and TOK helpers, citation formatting, rubric-aligned essay feedback.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[saulmcphd/apa-style](https://github.com/saulmcphd/apa-style)** - Proofreads papers against APA 7th edition rules with inline corrections.
+- **[anthropics/pdf](https://officialskills.sh/anthropics/skills/pdf)** - Extracts text from PDFs, creates new PDFs, and fills forms — useful for working with past papers and mark schemes.
+- **[anthropics/doc-coauthoring](https://officialskills.sh/anthropics/skills/doc-coauthoring)** - Collaborative document editing and co-authoring, handy for group IAs or shared EE drafts.
+
 
 Know an IB- or IGCSE-specific skill? Be the first to add one, see [Contributing](#contributing).
-
-</details>
 
 ### Study & Productivity
 
 Spaced repetition, time and task management, focus.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[jakedahn/pomodoro](https://github.com/jakedahn/pomodoro)** - Pomodoro timer skill that tracks and learns from your focus sessions.
 - **[hluaguo/learn-faster-kit](https://github.com/hluaguo/learn-faster-kit)** - AI learning coach with spaced repetition, syllabi, and progress tracking.
@@ -57,19 +53,18 @@ Spaced repetition, time and task management, focus.
 - **[ComposioHQ/awesome-claude-skills — file-organizer](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/file-organizer)** - Organizes files and folders, finds duplicates, and cleans up your digital workspace.
 - **[ComposioHQ/awesome-claude-skills — document-skills/pptx](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/document-skills/pptx)** - Creates, edits, and analyzes .pptx presentations.
 - **[zarazhangrui/frontend-slides](https://github.com/zarazhangrui/frontend-slides)** - Builds animation-rich HTML presentations from scratch or converted from PowerPoint files.
-- **[anthropics/skills — docx](https://github.com/anthropics/skills/tree/main/skills/docx)** - Creates and edits Word documents with tracked changes, comments, and formatting.
-- **[anthropics/skills — xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx)** - Creates and analyzes spreadsheets with formulas, charts, and data cleaning.
+- **[anthropics/docx](https://officialskills.sh/anthropics/skills/docx)** - Creates and edits Word documents with tracked changes, comments, and formatting.
+- **[anthropics/xlsx](https://officialskills.sh/anthropics/skills/xlsx)** - Creates and analyzes spreadsheets with formulas, charts, and data cleaning.
+- **[anthropics/internal-comms](https://officialskills.sh/anthropics/skills/internal-comms)** - Writes status reports, newsletters, and FAQs — good for group project updates and lab reports.
+- **[openai/transcribe](https://officialskills.sh/openai/skills/transcribe)** - Transcribes audio files to text with optional speaker diarization — great for recording and reviewing lectures.
 - **[sickn33/antigravity-awesome-skills — examprep-ai](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/examprep-ai)** - Converts syllabi, past papers, or notes into a ranked High Score Roadmap with MCQs and question prediction.
 - **[sickn33/antigravity-awesome-skills — bulletmind](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bulletmind)** - Converts any input into clean hierarchical bullet points for note-taking and summarization.
-
-</details>
 
 ### Coding & CS Education
 
 Algorithm and debugging explainers, learn-to-code starters; distinct from professional dev tooling.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[zarazhangrui/codebase-to-course](https://github.com/zarazhangrui/codebase-to-course)** - Turns any codebase into an interactive HTML course for beginners.
 - **[kirilxd/claude-tutor](https://github.com/kirilxd/claude-tutor)** - Personal tutor with adaptive quizzes and SM-2 spaced repetition.
@@ -78,59 +73,68 @@ Algorithm and debugging explainers, learn-to-code starters; distinct from profes
 - **[mattpocock/skills — git-guardrails-claude-code](https://github.com/mattpocock/skills/tree/main/skills/misc/git-guardrails-claude-code)** - Blocks dangerous git commands (push, reset --hard, clean) via Claude Code hooks.
 - **[ComposioHQ/awesome-claude-skills — developer-growth-analysis](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/developer-growth-analysis)** - Analyzes your Claude Code chat history to surface coding patterns and learning gaps.
 - **[ComposioHQ/awesome-claude-skills — artifacts-builder](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/artifacts-builder)** - Builds multi-component React/Tailwind HTML artifacts for interactive demos and projects.
+- **[anthropics/web-artifacts-builder](https://officialskills.sh/anthropics/skills/web-artifacts-builder)** - Builds complex claude.ai HTML artifacts with React and Tailwind — useful for CS project demos and interactive coursework submissions.
+- **[openai/jupyter-notebook](https://officialskills.sh/openai/skills/jupyter-notebook)** - Creates clean, reproducible Jupyter notebooks for experiments and tutorials — essential for data science coursework.
 - **[sickn33/antigravity-awesome-skills — code-documentation-code-explain](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/code-documentation-code-explain)** - Explains complex code through narratives, visual diagrams, and step-by-step breakdowns.
-
-</details>
 
 ### STEM Subjects
 
 Math, physics, and chemistry problem-solving helpers.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[googlarz/math-skill](https://github.com/googlarz/math-skill)** - Solves math problems step by step with built-in verification.
 - **[chrisvoncsefalvay/claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** - Builds interactive D3.js charts, graphs, and network diagrams for data analysis and reports.
+- **[openai/spreadsheet](https://officialskills.sh/openai/skills/spreadsheet)** - Creates, edits, analyzes, and visualizes spreadsheets with formulas — handy for physics data tables and chemistry calculations.
+- **[huggingface/hugging-face-datasets](https://officialskills.sh/huggingface/skills/hugging-face-datasets)** - Creates and manages datasets with SQL querying — useful for statistics and data science projects.
+
 
 Know a physics or chemistry skill worth adding? Be the first, see [Contributing](#contributing).
-
-</details>
 
 ### Writing & Humanities
 
 Essay structuring, literature analysis, language learning.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[Master-cai/Research-Paper-Writing-Skills](https://github.com/Master-cai/Research-Paper-Writing-Skills)** - Skill package for planning and writing research papers.
 - **[ComposioHQ/awesome-claude-skills — content-research-writer](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/content-research-writer)** - Researches sources, improves hooks, iterates on outlines, and adds citations to essays and articles.
 - **[xwmxcz/papers-skill](https://github.com/xwmxcz/papers-skill)** - Searches 200M+ papers on Semantic Scholar, inspects citations, and downloads arXiv PDFs.
 
-Know a literature analysis or language-learning skill? Be the first to add one, see [Contributing](#contributing).
 
-</details>
+Know a literature analysis or language-learning skill? Be the first to add one, see [Contributing](#contributing).
 
 ### College Applications & Career
 
 Personal statements, resume, interview prep.
 
-<details open>
-<summary>Show skills</summary>
+**Show skills**
 
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - Resume optimization, ATS scoring, and interview prep skills.
 - **[varunr89/resume-tailoring-skill](https://github.com/varunr89/resume-tailoring-skill)** - AI-powered resume tailoring for specific job descriptions.
 - **[AnayDhawan/oss-launch](https://github.com/AnayDhawan/oss-launch)** - Shipped a side project? Scaffold the OSS launch files (README/LICENSE/CI/launch plan) and use it as application signal.
 - **[ComposioHQ/awesome-claude-skills — domain-name-brainstormer](https://github.com/ComposioHQ/awesome-claude-skills/tree/main/domain-name-brainstormer)** - Generates domain name ideas and checks availability across TLDs for side projects.
 
-</details>
+### Google Workspace for Students
+
+Skills for Google's tools — Docs, Slides, Classroom, and more. Useful if your school runs on Google Workspace for Education.
+
+**Show skills**
+
+- **[googleworkspace/gws-docs](https://officialskills.sh/googleworkspace/skills/gws-docs)** - Read and write Google Docs documents via the `gws` CLI.
+- **[googleworkspace/gws-slides](https://officialskills.sh/googleworkspace/skills/gws-slides)** - Read and write Google Slides presentations via the `gws` CLI.
+- **[googleworkspace/gws-sheets](https://officialskills.sh/googleworkspace/skills/gws-sheets)** - Read and write Google Sheets spreadsheets via the `gws` CLI.
+- **[googleworkspace/gws-classroom](https://officialskills.sh/googleworkspace/skills/gws-classroom)** - Manage Google Classroom classes, rosters, and coursework via the `gws` CLI.
+- **[googleworkspace/gws-drive](https://officialskills.sh/googleworkspace/skills/gws-drive)** - Manage Google Drive files, folders, and shared drives — handy for keeping coursework organized.
+- **[googleworkspace/gws-tasks](https://officialskills.sh/googleworkspace/skills/gws-tasks)** - Manage Google Tasks task lists and tasks via the `gws` CLI.
+
+These skills require the [Google Workspace CLI (`gws`)](https://officialskills.sh/googleworkspace/skills/gws-shared) for auth. Install and authenticate once, then all `gws-*` skills work.
 
 ## Plugins
 
 Full Claude Code, Cursor, or Copilot plugins for students: bundles of commands, agents, hooks, or MCP servers, not a single skill file.
 
-<details open>
-<summary>Show plugins</summary>
+**Show plugins**
 
 - **[olegvg/resume-tailor-plugin](https://github.com/olegvg/resume-tailor-plugin)** - Claude Code plugin that tailors your resume to a job post.
 - **[JeanDiable/academic-research-plugin](https://github.com/JeanDiable/academic-research-plugin)** - Plugin for literature surveys, paper reviews, and citation management.
@@ -142,8 +146,6 @@ Full Claude Code, Cursor, or Copilot plugins for students: bundles of commands, 
 - **[dair-ai/dair-academy-plugins — lesson-generator](https://github.com/dair-ai/dair-academy-plugins/tree/main/plugins/lesson-generator)** - Generates multi-lesson HTML courses with flashcards, quizzes, objectives, and source links.
 - **[dair-ai/dair-academy-plugins — wiki-builder](https://github.com/dair-ai/dair-academy-plugins/tree/main/plugins/wiki-builder)** - Builds and maintains structured research wikis with sources, compiled pages, and derived artifacts.
 
-</details>
-
 ## Security Notice
 
 This list curates links, it does not vet or host the code behind them. Before installing any skill or plugin from this list:
@@ -152,16 +154,18 @@ This list curates links, it does not vet or host the code behind them. Before in
 - Check the author and repo activity. Prefer maintained repos with real usage over brand-new, unreviewed ones.
 - Never paste credentials, exam content, or personal data into a skill you have not read.
 
+
 If you find a listed entry that looks unsafe or abandoned, open an issue or PR removing it.
 
 ## Skill & Plugin Paths for Other AI Coding Assistants
 
-| Tool | Project path | Global path | Docs |
-|---|---|---|---|
-| Claude Code | `.claude/skills/` | `~/.claude/skills/` | [Agent Skills docs](https://code.claude.com/docs/en/skills) |
-| Cursor | `.cursor/rules/` | `~/.cursor/rules/` | [Cursor rules docs](https://docs.cursor.com/context/rules) |
-| GitHub Copilot | `.github/copilot-instructions.md` | N/A | [Copilot custom instructions](https://docs.github.com/en/copilot/customizing-copilot) |
-| Gemini CLI | `.gemini/` | `~/.gemini/` | [Gemini CLI docs](https://github.com/google-gemini/gemini-cli) |
+| Tool           | Project path                      | Global path         | Docs                                                                                  |
+| -------------- | --------------------------------- | ------------------- | ------------------------------------------------------------------------------------- |
+| Claude Code    | `.claude/skills/`                 | `~/.claude/skills/` | [Agent Skills docs](https://code.claude.com/docs/en/skills)                           |
+| Cursor         | `.cursor/rules/`                  | `~/.cursor/rules/`  | [Cursor rules docs](https://docs.cursor.com/context/rules)                            |
+| GitHub Copilot | `.github/copilot-instructions.md` | N/A                 | [Copilot custom instructions](https://docs.github.com/en/copilot/customizing-copilot) |
+| Gemini CLI     | `.gemini/`                        | `~/.gemini/`        | [Gemini CLI docs](https://github.com/google-gemini/gemini-cli)                        |
+
 
 Claude Code plugins (full bundles, not single skills) install via a marketplace `.claude-plugin/marketplace.json`, see the [Claude Code plugin docs](https://code.claude.com/docs/en/plugins).
 
@@ -174,6 +178,7 @@ An entry should meet all of the following before being added:
 - **Works.** Tested against at least one of the tools in the path table above.
 - **Real, not a stub.** Built for actual use, not a placeholder created just to pad this list.
 - **Short description.** One line, plain language, no marketing copy.
+
 
 ## Contributing
 


### PR DESCRIPTION
…  - Add anthropics/pdf, doc-coauthoring to IB & IGCSE section - Add anthropics/internal-comms, openai/transcribe to Study & Productivity - Add anthropics/web-artifacts-builder, openai/jupyter-notebook to Coding & CS Education - Add openai/spreadsheet, huggingface/hugging-face-datasets to STEM Subjects - Add new Google Workspace for Students section with gws-docs, gws-slides,   gws-sheets, gws-classroom, gws-drive, gws-tasks from googleworkspace skills

Removed unnecessary div tags and consolidated badge links. Added a new section for Google Workspace skills for students.