### PR TITLE
Add skill: 0xsarwagya/ontoly

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Algorithm and debugging explainers, learn-to-code starters, and CS project tooli
 - **[openai/jupyter-notebook](https://officialskills.sh/openai/skills/jupyter-notebook)** - Creates clean, reproducible Jupyter notebooks for experiments and tutorials — essential for data science coursework.
 - **[sickn33/antigravity-awesome-skills — code-documentation-code-explain](https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/code-documentation-code-explain)** - Explains complex code through narratives, visual diagrams, and step-by-step breakdowns.
 - **[FlorianBruniaux/claude-code-ultimate-guide — self-assessment](https://github.com/FlorianBruniaux/claude-code-ultimate-guide/tree/main/.claude/skills/self-assessment)** - Assesses your Claude Code skill level and generates a personalized learning path.
+- **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly)** - Maps codebases into graph-backed architecture evidence.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds Ontoly to Coding & CS Education.

Ontoly can help students and project teams map codebases into deterministic Software Graph evidence for architecture and dependency understanding.

## Validation

- Ran `git diff --check`

Note: a plain `markdownlint-cli2 README.md` run reports pre-existing README style violations unrelated to this one-line catalog addition.
