### PR TITLE
Add the sister-list cross-link footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Skills and plugins that run inside your AI coding agent (**Claude Code, Cursor, 
 | 🔵 | [Google Workspace for Students](#google-workspace-for-students) | 6 skills |
 | 🧩 | [Plugins](#plugins) | 15 plugins |
 
-[Compatibility Paths](#compatibility-paths) &middot; [Security Notice](#security-notice) &middot; [Quality Standards](#quality-standards) &middot; [Contributing](#contributing) &middot; [Contributors](#contributors) &middot; [More from StudentSuite](#more-from-studentsuite) &middot; [License](#license)
+[Compatibility Paths](#compatibility-paths) &middot; [Security Notice](#security-notice) &middot; [Quality Standards](#quality-standards) &middot; [Contributing](#contributing) &middot; [Contributors](#contributors) &middot; [More from StudentSuite](#more-from-studentsuite) &middot; [Sister lists](#sister-lists) &middot; [License](#license)
 
 ---
 
@@ -271,6 +271,12 @@ Thanks to everyone who has added a skill, fixed an entry, or improved the format
 ## More from StudentSuite
 
 Looking for software, tools, textbooks, and other resources beyond skills and plugins? See the sibling list: [awesome-student-resources](https://github.com/StudentSuite/awesome-student-resources).
+
+## Sister lists
+
+- [awesome-student-resources](https://github.com/StudentSuite/awesome-student-resources) - Tools, textbooks and channels for students.
+- [awesome-study-resources](https://github.com/StudentSuite/awesome-study-resources) - Exam and subject study material.
+- [awesome-skills-plugins-for-students](https://github.com/StudentSuite/awesome-skills-plugins-for-students) - AI coding agent skills and plugins.
 
 ## License
 


### PR DESCRIPTION
Closes #32.

## Entry

Not an entry PR. The entry fields below are N/A.

Repo: N/A

Skill or plugin: N/A

Why it helps students: N/A

## What this adds

The shared `## Sister lists` block, placed after "More from StudentSuite" and before "License", plus a `[Sister lists](#sister-lists)` link in the Table of Contents footer row so the section is reachable from the top like every other one.

The block is byte-identical to the one already in `awesome-student-resources` (diffed, no differences). `awesome-study-resources` does not have it yet and will need the same block to complete the set.

All three links resolve.

## Checklist

- [x] One entry per PR - N/A, no list entry
- [x] Added under the correct section, in alphabetical order (case-insensitive) - N/A, no list entry
- [x] Follows the entry format from [CONTRIBUTING.md](../CONTRIBUTING.md) - N/A, no list entry
- [x] Bumped the three counts - N/A, no list entry, counts unchanged
- [x] Meets the [Quality Standards](../README.md#quality-standards) - N/A, no list entry
- [x] Not a duplicate of an existing entry in the same section - checked, no existing Sister lists block in this README

`check-list-format` and `markdownlint` both pass in CI on this branch.
