### PR TITLE
ci: validate README count declarations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - README.md
       - scripts/check-list-format.mjs
+      - scripts/check-counts*.mjs
       - scripts/audit-duplicate-urls.mjs
   push:
     branches:
@@ -12,6 +13,7 @@ on:
     paths:
       - README.md
       - scripts/check-list-format.mjs
+      - scripts/check-counts*.mjs
       - scripts/audit-duplicate-urls.mjs
 
 jobs:
@@ -22,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 20
+      - run: node --test scripts/*.test.mjs
       - run: node scripts/check-list-format.mjs
       # Informational only: reports cross-section URL reuse, never fails the job.
       - run: node scripts/audit-duplicate-urls.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ One entry per PR keeps review fast. Every list is sorted alphabetically (case-in
 
 ## CI checks
 
-A CI check runs `scripts/check-list-format.mjs` on every PR that touches README.md. It verifies the entry format, alphabetical order, and that the Table of Contents matches the section headings. Run it yourself before opening a PR with:
+A CI check runs `scripts/check-list-format.mjs` on every PR that touches README.md. It verifies the entry format, alphabetical order, that the Table of Contents matches the section headings, and that the badge, Table of Contents, and section-summary counts match the actual entries. Run it yourself before opening a PR with:
 
 ```sh
 node scripts/check-list-format.mjs

--- a/scripts/check-counts.mjs
+++ b/scripts/check-counts.mjs
@@ -1,0 +1,138 @@
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .replace(/ /g, '-');
+}
+
+/**
+ * Check every count readers see in README.md against the resource bullets.
+ *
+ * @param {string} readme
+ * @returns {string[]} human-readable validation errors
+ */
+export function validateCountDeclarations(readme) {
+  const lines = readme.split('\n');
+  const errors = [];
+  const blocks = [];
+  let currentHeading = null;
+  let currentBlock = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const h2 = line.match(/^## (.+)/);
+    if (h2) currentHeading = h2[1].trim();
+
+    if (line.startsWith('<details')) {
+      currentBlock = {
+        heading: currentHeading,
+        line: i + 1,
+        count: 0,
+        summary: null,
+        sawSummary: false,
+      };
+      continue;
+    }
+
+    if (!currentBlock) continue;
+
+    if (line.startsWith('<summary>')) {
+      currentBlock.sawSummary = true;
+      const summary = line.match(/^<summary>Show (\d+) (skills|plugins)<\/summary>$/);
+      if (summary) {
+        currentBlock.summary = {
+          count: Number(summary[1]),
+          kind: summary[2],
+          line: i + 1,
+        };
+      } else {
+        errors.push(
+          `README.md:${i + 1}  Count summary must match "<summary>Show N skills|plugins</summary>".\n    ${line}`
+        );
+      }
+      continue;
+    }
+
+    if (line.startsWith('- ')) currentBlock.count++;
+
+    if (line.startsWith('</details>')) {
+      if (currentBlock.summary || currentBlock.count) blocks.push(currentBlock);
+      currentBlock = null;
+    }
+  }
+
+  const tocCounts = new Map();
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(
+      /\[(.+?)\]\(#(.+?)\)\s*\|\s*(\d+)\s+(skills|plugins)\s*\|\s*$/i
+    );
+    if (match) {
+      tocCounts.set(match[2], {
+        count: Number(match[3]),
+        kind: match[4].toLowerCase(),
+        line: i + 1,
+      });
+    }
+  }
+
+  const totals = { skills: 0, plugins: 0 };
+  const declaredTotals = { skills: 0, plugins: 0 };
+  const summariesComplete = { skills: true, plugins: true };
+  for (const block of blocks) {
+    const kind = block.heading === 'Plugins' ? 'plugins' : 'skills';
+    totals[kind] += block.count;
+
+    if (!block.sawSummary) {
+      errors.push(`README.md:${block.line}  Section "${block.heading}" is missing a count summary.`);
+    }
+    if (!block.summary) summariesComplete[kind] = false;
+    if (block.summary) {
+      declaredTotals[kind] += block.summary.count;
+      if (block.summary.count !== block.count) {
+        errors.push(
+          `README.md:${block.summary.line}  Summary count for "${block.heading}" is ${block.summary.count}, but the section contains ${block.count} ${kind}.`
+        );
+      }
+      if (block.summary.kind !== kind) {
+        errors.push(
+          `README.md:${block.summary.line}  Summary for "${block.heading}" says ${block.summary.kind}, but this is a ${kind} section.`
+        );
+      }
+    }
+
+    const toc = tocCounts.get(slugify(block.heading));
+    if (!toc) {
+      errors.push(`README.md:${block.line}  Section "${block.heading}" has no count in the Table of Contents.`);
+      continue;
+    }
+    if (toc.count !== block.count) {
+      errors.push(
+        `README.md:${toc.line}  Table of Contents count for "${block.heading}" is ${toc.count}, but the section contains ${block.count} ${kind}.`
+      );
+    }
+    if (toc.kind !== kind) {
+      errors.push(
+        `README.md:${toc.line}  Table of Contents count for "${block.heading}" says ${toc.kind}, but this is a ${kind} section.`
+      );
+    }
+  }
+
+  for (const kind of ['skills', 'plugins']) {
+    const label = kind[0].toUpperCase() + kind.slice(1);
+    const badgeLine = lines.findIndex((line) => line.startsWith(`![${label}](`));
+    const badge =
+      badgeLine === -1
+        ? null
+        : lines[badgeLine].match(new RegExp(`/badge/${kind}-(\\d+)-`, 'i'));
+    const expectedTotal = summariesComplete[kind] ? declaredTotals[kind] : totals[kind];
+    if (!badge) {
+      errors.push(`README.md  Missing or malformed ${label} count badge.`);
+    } else if (Number(badge[1]) !== expectedTotal) {
+      errors.push(
+        `README.md:${badgeLine + 1}  ${label} badge count is ${badge[1]}, but the section summaries total ${expectedTotal} ${kind}.`
+      );
+    }
+  }
+
+  return errors;
+}

--- a/scripts/check-counts.test.mjs
+++ b/scripts/check-counts.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { validateCountDeclarations } from './check-counts.mjs';
+
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+test('accepts the current README count declarations', () => {
+  assert.deepEqual(validateCountDeclarations(readme), []);
+});
+
+test('detects a stale section summary', () => {
+  const changed = readme.replace('<summary>Show 7 skills</summary>', '<summary>Show 8 skills</summary>');
+  const errors = validateCountDeclarations(changed);
+
+  assert(errors.some((error) => error.includes('Summary count for "IB & IGCSE Coursework" is 8')));
+  assert(errors.some((error) => error.includes('Skills badge count is 70')));
+});
+
+test('detects a stale Table of Contents count', () => {
+  const changed = readme.replace(
+    '[IB & IGCSE Coursework](#ib--igcse-coursework) | 7 skills',
+    '[IB & IGCSE Coursework](#ib--igcse-coursework) | 8 skills'
+  );
+  const errors = validateCountDeclarations(changed);
+
+  assert(
+    errors.some((error) =>
+      error.includes('Table of Contents count for "IB & IGCSE Coursework" is 8')
+    )
+  );
+});
+
+test('detects a stale aggregate badge', () => {
+  const changed = readme.replace('/badge/skills-70-blue', '/badge/skills-69-blue');
+  const errors = validateCountDeclarations(changed);
+
+  assert(errors.some((error) => error.includes('Skills badge count is 69')));
+});
+
+test('detects when actual entries drift from the section declarations', () => {
+  const changed = readme.replace(
+    /^- \*\*\[anthropics\/doc-coauthoring\].*\n/m,
+    ''
+  );
+  const errors = validateCountDeclarations(changed);
+
+  assert(errors.some((error) => error.includes('Summary count for "IB & IGCSE Coursework"')));
+  assert(errors.some((error) => error.includes('Table of Contents count for "IB & IGCSE Coursework"')));
+  assert.equal(errors.some((error) => error.includes('Skills badge count is 70')), false);
+});
+
+test('detects a missing section summary', () => {
+  const changed = readme.replace('<summary>Show 7 skills</summary>\n', '');
+  const errors = validateCountDeclarations(changed);
+
+  assert(errors.some((error) => error.includes('is missing a count summary')));
+});

--- a/scripts/check-list-format.mjs
+++ b/scripts/check-list-format.mjs
@@ -4,14 +4,17 @@
 //   - entries within each list are sorted alphabetically, case-insensitive
 //   - no duplicate URLs within the same list
 //   - every section heading has a matching Table of Contents entry, and vice versa
+//   - section and badge counts match the actual number of entries
 
 import { readFileSync } from 'node:fs';
+import { validateCountDeclarations } from './check-counts.mjs';
 
 const README_PATH = new URL('../README.md', import.meta.url);
 const readme = readFileSync(README_PATH, 'utf8');
 const lines = readme.split('\n');
 
 const errors = [];
+errors.push(...validateCountDeclarations(readme));
 
 function slugify(text) {
   return text
@@ -127,5 +130,7 @@ if (errors.length) {
   for (const e of errors) console.error(`  ${e}\n`);
   process.exit(1);
 } else {
-  console.log('✔ README.md list format, alphabetical order, and Table of Contents all check out.');
+  console.log(
+    '✔ README.md list format, alphabetical order, Table of Contents, and counts all check out.'
+  );
 }


### PR DESCRIPTION
Closes #76.

## What this changes

- adds a focused count validator for section summaries, Table of Contents rows, and top-level Skills/Plugins badges
- counts the actual resource bullets in every list section and reports line-specific drift
- adds Node test coverage for valid counts, stale declarations, changed entries, and missing summaries
- runs the tests in the existing lint workflow and documents the expanded check

## Verification

- `node --test scripts/*.test.mjs` (6 passed)
- `node scripts/check-list-format.mjs`
- `node scripts/audit-duplicate-urls.mjs`
- Node 20 test and validator runs
- `markdownlint-cli2` (0 issues)
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## Entry

Repo: N/A — this is a CI/tooling change.

Skill or plugin: N/A

Why it helps students: N/A

## Checklist

- [x] One entry per PR — N/A, no list entry
- [x] Correct section and alphabetical order — N/A, no list entry
- [x] Entry format — N/A, no list entry
- [x] Bumped the three counts — N/A, counts are intentionally unchanged
- [x] Quality Standards — N/A, no linked project
- [x] Not a duplicate — N/A, no list entry